### PR TITLE
POM updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,11 @@
 			<artifactId>opensftp-impl</artifactId>
 			<version>0.3.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jasypt</groupId>
+			<artifactId>jasypt</artifactId>
+			<version>1.9.2</version>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,21 @@
 			<version>2.4</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.xeustechnologies</groupId>
+			<artifactId>jtar</artifactId>
+			<version>1.1</version>
+		</dependency>
+		<dependency>
+			<groupId>net.sf</groupId>
+			<artifactId>opensftp-api</artifactId>
+			<version>0.3</version>
+		</dependency>
+		<dependency>
+			<groupId>net.sf</groupId>
+			<artifactId>opensftp-impl</artifactId>
+			<version>0.3.0</version>
+		</dependency>
 	</dependencies>
 
 </project>


### PR DESCRIPTION
These should fix some of the compile problems associated with PeakInvestigator.

Read the `411d705` commit log for instructions on how to add OpenSftp to a local maven repo.
