### PR TITLE
Version cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,27 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>buildnumber-maven-plugin</artifactId>
+				<version>1.3</version>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<goals>
+							<goal>create</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<doCheck>false</doCheck>
+					<doUpdate>false</doUpdate>
+					<format>{0,date,yyyy-MM-dd HH:mm:ss}</format>
+					<items>
+						<item>timestamp</item>
+					</items>
+				</configuration> 
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.3</version>
@@ -74,7 +95,12 @@
 						<index>true</index>
 						<manifest>
 							<addClasspath>false</addClasspath>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
 						</manifest>
+						<manifestEntries>
+							<Implementation-Build>${buildNumber}</Implementation-Build>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>

--- a/src/main/java/net/sf/mzmine/main/MZmineCore.java
+++ b/src/main/java/net/sf/mzmine/main/MZmineCore.java
@@ -61,7 +61,6 @@ import net.sf.mzmine.util.ExitCode;
 public final class MZmineCore {
 
 	public static final String MZmineName      = "MZmine PeakInvestigator™ Edition";
-	public static final String MZmineShortName = "MZminePI";
 	
 	public static       boolean VtmxLive       = true;			// live or test server (also affects debug level)
 	public static       String  MZmineVersion  = "2.17.01";
@@ -104,7 +103,9 @@ public final class MZmineCore {
 
 	// Configure the logging properties before we start logging
 	try {
-	    InputStream loggingProperties = new FileInputStream("resources/" + MZmineShortName + ".logging.properties");
+	    ClassLoader cl = MZmineCore.class.getClassLoader();
+	    InputStream loggingProperties = cl
+		    .getResourceAsStream("logging.properties");
 	    LogManager logMan = LogManager.getLogManager();
 	    logMan.readConfiguration(loggingProperties);
 	    loggingProperties.close();

--- a/src/main/java/net/sf/mzmine/main/MZmineCore.java
+++ b/src/main/java/net/sf/mzmine/main/MZmineCore.java
@@ -28,6 +28,8 @@ import java.util.Hashtable;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
@@ -102,8 +104,9 @@ public final class MZmineCore {
 	 		}
 
 	// Configure the logging properties before we start logging
+	ClassLoader cl = MZmineCore.class.getClassLoader();
+
 	try {
-	    ClassLoader cl = MZmineCore.class.getClassLoader();
 	    InputStream loggingProperties = cl
 		    .getResourceAsStream("logging.properties");
 	    LogManager logMan = LogManager.getLogManager();
@@ -113,7 +116,17 @@ public final class MZmineCore {
 	    e.printStackTrace();
 	}
 
-	logger.info("Starting " + MZmineName + " " + MZmineVersion + " built " + MZmineDate);
+	String name = null, buildDate = null;
+	try {
+	    Manifest manifest = new Manifest(cl.getResourceAsStream("META-INF/MANIFEST.MF"));
+	    Attributes attributes = manifest.getMainAttributes();
+	    name = attributes.getValue("Implementation-Title");
+	    buildDate = attributes.getValue("Implementation-Build");
+	} catch (IOException e1) {
+	    // TODO Auto-generated catch block
+	    e1.printStackTrace();
+	}
+	logger.info("Starting " + name + " " + MZmineVersion + " built " + buildDate);
 	logger.info("CWD is " + new File(".").getAbsolutePath());
 
 	// Remove old temporary files, if we find any


### PR DESCRIPTION
This is the start of the approach I was thinking of for replacing some of the Version strings.
- `MZmineShortName` was only used to label the `logging.properties` file, which is identical (?) for both MZmine upstream and MZminePI. So, it can be removed and the section for parsing the `logging.properties` can be reverted back to the upstream version.
- The Maven buildNumber plugin allows a compile-time version info. This formats the build timestamp into a human readable string `yyyy-MM-dd HH:mm:ss`. Currently, the POM places this timestamp in the MANIFEST.MF file of the main JAR.
- I've started the work on parsing the info from the MANIFEST file, but it's pulling it from a library JAR instead of the mzmine JAR. If we can get this approach to work, then the only places we need to specify MZmine PeakInvestigator Edition is inside the POM `<name>` attribute.
