### PR TITLE
Allow Scan export dialog to choose output directory

### DIFF
--- a/src/main/java/net/sf/mzmine/datamodel/Scan.java
+++ b/src/main/java/net/sf/mzmine/datamodel/Scan.java
@@ -131,9 +131,10 @@ public interface Scan extends MassSpectrum {
      * Return the number of datapoints in the scan or mass list.
      * 
      * @param String massListName or if empty to export scan data points
+     * @param String directory to save scan
      * @param String filename to export to, if empty, filename will be generated from scan information
      * @return number of points, 0 if requested mass list not found not found
      */
-    public int exportToFile(@Nonnull String massListName, @Nonnull String filename);
+    public int exportToFile(@Nonnull String massListName, @Nonnull String saveDirectory, @Nonnull String filename);
 
 }

--- a/src/main/java/net/sf/mzmine/datamodel/impl/SimpleScan.java
+++ b/src/main/java/net/sf/mzmine/datamodel/impl/SimpleScan.java
@@ -389,7 +389,7 @@ public class SimpleScan implements Scan {
     }
     
     @Override
-    public int exportToFile(@Nonnull String massListName, @Nonnull String filename) {
+    public int exportToFile(@Nonnull String massListName, @Nonnull String saveDirectory, @Nonnull String filename) {
     // TODO Auto-generated method stub
     	return 0;
     }

--- a/src/main/java/net/sf/mzmine/modules/masslistmethods/listexport/ListExportParameters.java
+++ b/src/main/java/net/sf/mzmine/modules/masslistmethods/listexport/ListExportParameters.java
@@ -25,6 +25,7 @@ import net.sf.mzmine.main.MZmineCore;
 import net.sf.mzmine.parameters.Parameter;
 import net.sf.mzmine.parameters.impl.SimpleParameterSet;
 import net.sf.mzmine.parameters.parametertypes.BooleanParameter;
+import net.sf.mzmine.parameters.parametertypes.filenames.DirectoryParameter;
 import net.sf.mzmine.parameters.parametertypes.MassListParameter;
 import net.sf.mzmine.parameters.parametertypes.selectors.RawDataFilesParameter;
 import net.sf.mzmine.util.ExitCode;
@@ -36,10 +37,12 @@ public class ListExportParameters extends SimpleParameterSet
 	public static final      BooleanParameter dumpScans = new BooleanParameter(
 			"Export original scans",
 			"If checked, original scan data will be exported to text files");
+	public static final DirectoryParameter saveDirectory = new DirectoryParameter("Save to directory",
+			"Directory to save scans");
 
 	public ListExportParameters()
 	{
-		super(new Parameter[] { dataFiles, dumpScans, massList });
+		super(new Parameter[] { dataFiles, dumpScans, massList, saveDirectory });
 	}
 
 	public ExitCode showSetupDialog()

--- a/src/main/java/net/sf/mzmine/modules/masslistmethods/listexport/ListExportTask.java
+++ b/src/main/java/net/sf/mzmine/modules/masslistmethods/listexport/ListExportTask.java
@@ -43,6 +43,7 @@ public class ListExportTask extends AbstractTask
 	private boolean dumpScans;
 	private boolean dumpPeaks;
 	private String  massListName;
+	private String  saveDirectory;
 	
 	/**
 	 * @param dataFile
@@ -53,6 +54,7 @@ public class ListExportTask extends AbstractTask
 		this.dataFile = dataFile;
 		dumpScans     = parameters.getParameter(ListExportParameters.dumpScans).getValue();
 		massListName  = parameters.getParameter(ListExportParameters.massList).getValue();
+		saveDirectory = parameters.getParameter(ListExportParameters.saveDirectory).getValue().getPath();
 		dumpPeaks = (massListName.isEmpty() == false);
 	}
 
@@ -97,10 +99,10 @@ public class ListExportTask extends AbstractTask
 
 			Scan scan = dataFile.getScan(scanNumbers[s]);
 			if (dumpScans)
-				scan.exportToFile("", "");
+				scan.exportToFile("", saveDirectory, "");
 
 			if (dumpPeaks)
-				scansWithMassList += (scan.exportToFile(massListName, "") > 0) ? 1 : 0;
+				scansWithMassList += (scan.exportToFile(massListName, saveDirectory, "") > 0) ? 1 : 0;
 
 			processedScans++;
 		}

--- a/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/mascot/data/PeptideScan.java
+++ b/src/main/java/net/sf/mzmine/modules/peaklistmethods/identification/mascot/data/PeptideScan.java
@@ -456,7 +456,7 @@ public class PeptideScan implements Scan {
     }
 
     @Override
-    public int exportToFile(@Nonnull String massListName, @Nonnull String filename) {
+    public int exportToFile(@Nonnull String massListName, @Nonnull String saveDirectory, @Nonnull String filename) {
     // TODO Auto-generated method stub
     return 0;
     }

--- a/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/PeakInvestigator/PeakInvestigatorTask.java
+++ b/src/main/java/net/sf/mzmine/modules/rawdatamethods/peakpicking/massdetection/PeakInvestigator/PeakInvestigatorTask.java
@@ -215,7 +215,7 @@ public class PeakInvestigatorTask
 		try {
 			// export the scan to a file
 			String filename = "scan_" + String.format("%04d", scan_num) + ".txt";
-			scan.exportToFile("", filename);
+			scan.exportToFile("", "", filename);
 
 			// put the exported scan into the tar file
 			File f = new File(filename);

--- a/src/main/java/net/sf/mzmine/project/impl/StorableScan.java
+++ b/src/main/java/net/sf/mzmine/project/impl/StorableScan.java
@@ -19,6 +19,7 @@
 
 package net.sf.mzmine.project.impl;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.BufferedWriter;
@@ -48,7 +49,6 @@ import net.sf.mzmine.util.ScanUtils;
 import org.apache.commons.io.FilenameUtils;
 
 import com.veritomyx.FileChecksum;
-
 import com.google.common.collect.Range;
 
 /**
@@ -505,15 +505,20 @@ public class StorableScan implements Scan {
      * Return the number of datapoints in the scan or mass list.
      * 
      * @param massListName		// if empty, export scan data points
+     * @param saveDirectory		// if empty, saveDirectory isn't pre-pended to filename before export
      * @param filename			// if empty, filename will be generated from scan information
      * @return					// number of points, 0 if requested mass list not found not found
      */
-    public int exportToFile(String massListName, String filename)
+    public int exportToFile(String massListName, String saveDirectory, String filename)
     {
     	int exported = 0;
+
     	if (filename.isEmpty())
     		filename = exportFilename(massListName);
-    
+
+	if (!saveDirectory.isEmpty())
+	    	filename = saveDirectory + File.separator + filename;
+
     	if (massListName.isEmpty())	// export scan
     	{
     		logger.info("Exporting scan " + getScanNumber() + " to file " + filename);


### PR DESCRIPTION
This is one of the requested features for Gamma.

It isn't actually exporting the original scans, and your current master doesn't allow any of the Mass Detectors to work (`false` is passed to a method, and is related to the file you asked Tomas about), so I can't test exporting mass (peak) lists yet.
